### PR TITLE
Update AssemblyLoadContext version to 3.0.0.0

### DIFF
--- a/src/Shell.c
+++ b/src/Shell.c
@@ -381,7 +381,7 @@ void MI_CALL Shell_Load(Shell_Self** self, MI_Module_Self* selfModule,
     ret = createDelegate(
         (*self)->hostHandle,
         (*self)->domainId,
-        "Microsoft.PowerShell.CoreCLR.AssemblyLoadContext, Version=1.0.0.0, PublicKeyToken=31bf3856ad364e35",
+        "Microsoft.PowerShell.CoreCLR.AssemblyLoadContext, Version=3.0.0.0, PublicKeyToken=31bf3856ad364e35",
         "System.Management.Automation.PowerShellAssemblyLoadContextInitializer",
         "WSManPluginWrapper",
         (void**)&entryPointDelegate);


### PR DESCRIPTION
When https://github.com/PowerShell/PowerShell/pull/1637 is merged to PowerShell, PSRP will no longer work until this update is merged. Perhaps merge it as soon as we drop `alpha.8` (which will likely also require updates to the `CORE_ROOT` default path per https://github.com/PowerShell/PowerShell/issues/1309#issuecomment-237390207).
