### PR TITLE
Reference PowerShell's new binary name: pwsh

### DIFF
--- a/installbuilder/GNUmakefile
+++ b/installbuilder/GNUmakefile
@@ -6,7 +6,7 @@ ifeq ($(PF),Linux)
 DISTRO_TYPE = $(PF)_$(PF_DISTRO)
 endif
 
-PSRP_VERSION = 1.3.0
+PSRP_VERSION = 1.4.0
 PSRP_PATCH_LEVEL = $(shell if [ -z "$$BUILD_NUMBER" ]; then echo "0"; else echo $$BUILD_NUMBER; fi)
 
 INTERMEDIATE_DIR = $(TOP)/intermediate

--- a/src/coreclrutil.cpp
+++ b/src/coreclrutil.cpp
@@ -186,9 +186,9 @@ int startCoreCLR(
     if (clrAbsolutePath.empty())
     {
 #if defined(__APPLE__)
-        clrAbsolutePath = std::string("/usr/local/bin/powershell");
+        clrAbsolutePath = std::string("/usr/local/bin/pwsh");
 #else
-        clrAbsolutePath = std::string("/usr/bin/powershell");
+        clrAbsolutePath = std::string("/usr/bin/pwsh");
 #endif
         char realPath[PATH_MAX + 1];
         char *ptr = realpath(clrAbsolutePath.c_str(), realPath);


### PR DESCRIPTION
Fix https://github.com/PowerShell/psl-omi-provider/issues/104
Fix https://github.com/PowerShell/PowerShell/issues/4976

1: Update startCoreCLR in coreclrutil.cpp to reference PowerShell Core's new binary name pwsh.
2: Updates the omi submodule to depend on v1.4.0-4
3: Changes the PSRP version to 1.4.0 to match the OMI dependency.  (see https://github.com/Microsoft/omi/commit/b6110b3afb92ea4e922c959ed7ddf49e02fd6cab)
