### PR TITLE
Use Async MI_Session_Close to avoid possible deadlock.

### DIFF
--- a/src/Client.c
+++ b/src/Client.c
@@ -2362,9 +2362,11 @@ error:
     return;
 }
 
-void MI_CALL CloseSessionComplete(
-    __LOGD(("%s: END", "CloseSessionComplete"));
+void MI_CALL CloseSessionComplete(_In_opt_ void *competionContext
 )
+{
+    __LOGD(("%s: END", "CloseSessionComplete"));
+}
 
 void MI_CALL CloseShellComplete(
     _In_opt_     MI_Operation *miOperation,

--- a/src/Client.c
+++ b/src/Client.c
@@ -2362,6 +2362,10 @@ error:
     return;
 }
 
+void MI_CALL CloseSessionComplete(
+    __LOGD(("%s: END", "CloseSessionComplete"));
+)
+
 void MI_CALL CloseShellComplete(
     _In_opt_     MI_Operation *miOperation,
     _In_     void *callbackContext,
@@ -2397,7 +2401,8 @@ void MI_CALL CloseShellComplete(
                 NULL,
                 NULL);
     MI_Operation_Close(miOperation);
-    MI_Session_Close(&shell->miSession, NULL, NULL);
+    __LOGD(("%s: START", "CloseSessionComplete"));
+    MI_Session_Close(&shell->miSession, NULL, CloseSessionComplete);
     __LOGD(("%s: END, errorCode=%u", "CloseShellComplete", resultCode));
 }
 MI_EXPORT void WINAPI WSManCloseShell(


### PR DESCRIPTION
The changes to use a single protocol thread can result in a deadlock if a callback submits blocking call from the protocol thread.  This is seen with calls to MI_Session_Close. The fix is to close the session asynchronously.

Fixes https://github.com/PowerShell/psl-omi-provider/issues/112
Fixes https://github.com/PowerShell/PowerShell/issues/5685