### PR TITLE
Mark recieved data as binary, not text.

### DIFF
--- a/src/Client.c
+++ b/src/Client.c
@@ -1605,9 +1605,9 @@ MI_Result DecodeReceiveStream(WSMAN_OPERATION_HANDLE operation, const MI_Instanc
 
     /* TODO!! Support compression */
     responseData.receiveData.exitCode = 0;
-    responseData.receiveData.streamData.type = WSMAN_DATA_TYPE_TEXT;
-    responseData.receiveData.streamData.text.buffer = (MI_Char16*) decodedBuffer.buffer;
-    responseData.receiveData.streamData.text.bufferLength = decodedBuffer.bufferUsed;
+    responseData.receiveData.streamData.type = WSMAN_DATA_TYPE_BINARY;
+    responseData.receiveData.streamData.binaryData.data = (MI_Uint8*) decodedBuffer.buffer;
+    responseData.receiveData.streamData.binaryData.dataLength = decodedBuffer.bufferUsed;
 
     flags = 0;
     if (streamComplete)


### PR DESCRIPTION
Fix: https://github.com/PowerShell/psl-omi-provider/issues/121

DecodeReceiveStream was marking the stream data as WSMAN_DATA_TYPE_TEXT when it should have been WSMAN_DATA_TYPE_BINARY.   When running a debug build of PowerShell Core, it was asserting that the type should be BINARY and failing making PSRP unusable with debug builds of PowerShell Core.