### PR TITLE
Set default -Authentication to Negotiate

### DIFF
--- a/src/Client.c
+++ b/src/Client.c
@@ -257,11 +257,12 @@ MI_EXPORT MI_Uint32 WINAPI WSManCreateSession(
         case WSMAN_FLAG_AUTH_BASIC:
             userCredentials.authenticationType = MI_AUTH_TYPE_BASIC;
             break;
-        case WSMAN_FLAG_AUTH_NEGOTIATE:
-            userCredentials.authenticationType = MI_AUTH_TYPE_NEGO_WITH_CREDS;
-            break;
         case WSMAN_FLAG_AUTH_KERBEROS:
             userCredentials.authenticationType = MI_AUTH_TYPE_KERBEROS;
+            break;
+        case WSMAN_FLAG_AUTH_NEGOTIATE:
+        case WSMAN_FLAG_DEFAULT_AUTHENTICATION:
+            userCredentials.authenticationType = MI_AUTH_TYPE_NEGO_WITH_CREDS;
             break;
         default:
             GOTO_ERROR("Unsupported authentication type", MI_RESULT_ACCESS_DENIED);


### PR DESCRIPTION
I know the contributor section says PRs aren't accepted and to open an issue for an RFC but this was quite a simple fix so I decided to open the PR instead.

On Windows the absence of `-Authentication` for the PSSession WSMan parameters means to use `Negotiate` auth. On Linux if you omit the the `-Authentication` parameter then it will fail with the error

> Enter-PSSession: MI_RESULT_ACCESS_DENIED

This PR just sets the default value for `-Authentication` to be the same as `-Authentication Negotiate` to match the same behaviour on Windows.